### PR TITLE
added tests that demonstrate library weaknesses

### DIFF
--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -126,6 +126,17 @@ class AddressTest(unittest.TestCase):
         self.assertTrue(addr.zip == None)
         self.assertTrue(addr.apartment == None)
         # self.assertTrue(addr.building == None)
+    
+    def test_multi_word_city(self):
+        addr = Address('351 King St. #400, San Francisco, CA, 94158', self.parser)
+        self.assertEqual('351', addr.house_number)
+        self.assertEqual('San Francisco', addr.city)
+        self.assertEqual('#400', addr.apartment)
+    
+    def test_street_postdirection(self):
+        addr = Address('12006 120th Pl NE, Kirkland, WA', self.parser)
+        self.assertEqual('NE', addr.post_direction)
+    
 
     # Not yet passing.
     #def test_5_digit_house_number(self):


### PR DESCRIPTION
pyaddress has problems with multi word cities. 

I couldn't find the issues tab to submit under so here goes: 
We shouldn't stop processing when there is no house number. It is perfectly valid for a house to not have a street number: e.g. a majority of Carmel California
There are some naming issues. pyaddress is missing street post direction.  e.g. 12006 120th Pl NE, Kirkland, WA
ambiguous naming: apartment should be unit_designator or simply designator.
designators include apartment, unit, suite, department, etc.
unit numbers should go into a designator_number. eg unit 38 should not lose it's designation
More than anything here needs to be consistency in the naming. 
we should refer to USPS Publication 28: http://pe.usps.com/text/pub28/welcome.htm
